### PR TITLE
Fix program restart call for older C# versions

### DIFF
--- a/reShutCLI/ErrorHandler.cs
+++ b/reShutCLI/ErrorHandler.cs
@@ -73,7 +73,7 @@ namespace reShutCLI
                 UIDraw.DrawCenteredLine("│ " + lines[3].PadRight(boxWidth - 2) + " │");
                 UIDraw.DrawCenteredLine(bottomBorder);
                 Console.ReadKey();
-                Program.Main([]);
+                Program.Main(Array.Empty<string>());
             }
         }
     }


### PR DESCRIPTION
## Summary
- Use `Array.Empty<string>()` when relaunching the program after an error, avoiding use of C# collection expressions that may not compile on older compilers

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_689f75a3f0e08321a5be484cc6eaa277