### PR TITLE
Annotate Windows-specific APIs to satisfy analyzers

### DIFF
--- a/reShutCLI/AssemblyInfo.cs
+++ b/reShutCLI/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]
+

--- a/reShutCLI/ErrorHandler.cs
+++ b/reShutCLI/ErrorHandler.cs
@@ -3,11 +3,13 @@ using System.Globalization;
 using System.Linq;
 using System.Resources;
 using System.Text;
+using System.Runtime.Versioning;
 
 namespace reShutCLI
 {
     internal class ErrorHandler
     {
+        [SupportedOSPlatform("windows")]
         public static void SetConsoleSize(int width, int height)
         {
             if (Console.LargestWindowWidth >= width && Console.LargestWindowHeight >= height)

--- a/reShutCLI/Handler.cs
+++ b/reShutCLI/Handler.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using System.Runtime.Versioning;
 /// <summary>
 /// Provides methods to perform system-level operations such as rebooting, shutting down, or logging off the current
 /// user.
@@ -11,6 +12,7 @@ using System.Security.Principal;
 /// cref="Reboot"/> and <see cref="Shutdown"/> methods require administrative privileges  and attempt to enable the
 /// necessary shutdown privilege before executing the operation. The <see cref="Logoff"/> method does not require
 /// administrative privileges.</remarks>
+[SupportedOSPlatform("windows")]
 internal class Handler
 {
     [DllImport("user32.dll", SetLastError = true)]

--- a/reShutCLI/Program.cs
+++ b/reShutCLI/Program.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Resources;
 using System.Text;
 using System.Threading;
+using System.Runtime.Versioning;
 namespace reShutCLI;
 
 /// <summary>
 /// Main class for the reShut CLI application.
 /// Handles application initialization, main loop, UI rendering, and input processing.
 /// </summary>
+[SupportedOSPlatform("windows")]
 internal class Program
 {
 

--- a/reShutCLI/RegistryWorker.cs
+++ b/reShutCLI/RegistryWorker.cs
@@ -5,6 +5,7 @@ using System.Runtime.Versioning;
 namespace reShutCLI
 {
     // Updated for 2.0.0.0
+    [SupportedOSPlatform("windows")]
     class RegistryWorker
     {
 

--- a/reShutCLI/cmdLine.cs
+++ b/reShutCLI/cmdLine.cs
@@ -5,6 +5,7 @@ using System.Runtime.Versioning;
 
 namespace reShutCLI
 {
+    [SupportedOSPlatform("windows")]
     internal class CmdLine
     {
 


### PR DESCRIPTION
## Summary
- Annotate handler, registry, and command-line classes with `[SupportedOSPlatform("windows")]`
- Mark assembly as Windows-only
- Guard console resizing with Windows platform attribute

## Testing
- `~/dotnet/dotnet build -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_b_689f9e63e5a08322a8730354a0f7d43b