### PR TITLE
Fix compilation errors in reShut CLI

### DIFF
--- a/reShutCLI/RemoteManager.cs
+++ b/reShutCLI/RemoteManager.cs
@@ -9,36 +9,38 @@ internal static class RemoteManager
 {
     public static bool Trigger(string host, string? username, string? password, bool reboot)
     {
-        try
-        {
-            ConnectionOptions options = new ConnectionOptions();
-            if (!string.IsNullOrWhiteSpace(username))
+            try
             {
-                options.Username = username;
-                options.Password = password ?? string.Empty;
+                ConnectionOptions options = new ConnectionOptions();
+                if (!string.IsNullOrWhiteSpace(username))
+                {
+                    options.Username = username;
+                    options.Password = password ?? string.Empty;
+                }
+
+                ManagementScope scope = new ManagementScope($"\\\\{host}\\root\\cimv2", options);
+                scope.Connect();
+
+                ObjectQuery query = new ObjectQuery("SELECT * FROM Win32_OperatingSystem");
+                using ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, query);
+                foreach (ManagementObject os in searcher.Get())
+                {
+                    os.InvokeMethod("Win32Shutdown", new object[] { reboot ? 6 : 5, 0 });
+                }
+
+                UIDraw.TextColor = ConsoleColor.Green;
+                UIDraw.DrawLine($"Remote {(reboot ? "reboot" : "shutdown")} triggered on {host}.");
+                return true;
             }
-
-            ManagementScope scope = new ManagementScope($"\\\\{host}\\root\\cimv2", options);
-            scope.Connect();
-
-            ObjectQuery query = new ObjectQuery("SELECT * FROM Win32_OperatingSystem");
-            using ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, query);
-            foreach (ManagementObject os in searcher.Get())
+            catch (Exception ex)
             {
-                os.InvokeMethod("Win32Shutdown", new object[] { reboot ? 6 : 5, 0 });
+                UIDraw.TextColor = ConsoleColor.Red;
+                UIDraw.DrawLine($"Remote operation failed: {ex.Message}");
+                return false;
             }
-
-            UIDraw.TextColor = ConsoleColor.Green;
-            UIDraw.DrawLine($"Remote {(reboot ? "reboot" : "shutdown")} triggered on {host}.");
-        }
-        catch (Exception ex)
-        {
-            UIDraw.TextColor = ConsoleColor.Red;
-            UIDraw.DrawLine($"Remote operation failed: {ex.Message}");
-        }
-        finally
-        {
-            UIDraw.TextColor = ConsoleColor.White;
-        }
+            finally
+            {
+                UIDraw.TextColor = ConsoleColor.White;
+            }
     }
 }

--- a/reShutCLI/Schedule.cs
+++ b/reShutCLI/Schedule.cs
@@ -162,28 +162,23 @@ namespace reShutCLI
                             string scheduleType = recur == "d" ? "DAILY" : "WEEKLY";
                             string taskName = $"reShutCLI_{Guid.NewGuid().ToString("N")}";
                             string st = targetTime.ToString("HH:mm");
-                            var psi = new ProcessStartInfo
-                            {
-                                FileName = "schtasks",
-                                Arguments = $"/Create /TN {taskName} /TR \"shutdown /{character} /f\" /SC {scheduleType} /ST {st}",
-                                RedirectStandardOutput = true,
-                                RedirectStandardError = true,
-                                UseShellExecute = false,
-                                CreateNoWindow = true
-                                RedirectStandardOutput = true,
-                                RedirectStandardError = true,
-                                UseShellExecute = false,
-                                CreateNoWindow = true
-                            };
-                            psi.ArgumentList.Add("/Create");
-                            psi.ArgumentList.Add("/TN");
-                            psi.ArgumentList.Add(taskName);
-                            psi.ArgumentList.Add("/TR");
-                            psi.ArgumentList.Add($"shutdown /{character} /f");
-                            psi.ArgumentList.Add("/SC");
-                            psi.ArgumentList.Add(scheduleType);
-                            psi.ArgumentList.Add("/ST");
-                            psi.ArgumentList.Add(st);
+                              var psi = new ProcessStartInfo
+                              {
+                                  FileName = "schtasks",
+                                  RedirectStandardOutput = true,
+                                  RedirectStandardError = true,
+                                  UseShellExecute = false,
+                                  CreateNoWindow = true
+                              };
+                              psi.ArgumentList.Add("/Create");
+                              psi.ArgumentList.Add("/TN");
+                              psi.ArgumentList.Add(taskName);
+                              psi.ArgumentList.Add("/TR");
+                                psi.ArgumentList.Add($"shutdown /{character} /f");
+                              psi.ArgumentList.Add("/SC");
+                              psi.ArgumentList.Add(scheduleType);
+                              psi.ArgumentList.Add("/ST");
+                              psi.ArgumentList.Add(st);
                             using (var process = Process.Start(psi))
                             {
                                 process.WaitForExit();

--- a/reShutCLI/cmdLine.cs
+++ b/reShutCLI/cmdLine.cs
@@ -33,8 +33,6 @@ namespace reShutCLI
                 }
             }
 
-            if (parsed.TryGetValue("remote", out string host))
-            if (parsed.TryGetValue("remote", out string? host))
             if (parsed.TryGetValue("remote", out string? host))
             {
                 if (host is null)
@@ -48,16 +46,18 @@ namespace reShutCLI
                 parsed.TryGetValue("pass", out string? pass);
                 bool reboot = parsed.ContainsKey("r") || parsed.ContainsKey("reboot");
                 bool shutdown = parsed.ContainsKey("s") || parsed.ContainsKey("shutdown") || parsed.ContainsKey("poweroff");
+                bool result;
 
                 if (reboot)
-                    RemoteManager.Trigger(host, user, pass, true);
+                    result = RemoteManager.Trigger(host, user, pass, true);
                 else if (shutdown)
-                    RemoteManager.Trigger(host, user, pass, false);
+                    result = RemoteManager.Trigger(host, user, pass, false);
                 else
                 {
                     UIDraw.TextColor = Variables.SecondaryColor;
                     UIDraw.DrawLine("Remote host specified but no action (-r/-s) provided.");
                     UIDraw.TextColor = ConsoleColor.Gray;
+                    result = false;
                 }
 
                 if (result)

--- a/reShutCLI/reShutCLI.csproj
+++ b/reShutCLI/reShutCLI.csproj
@@ -6,6 +6,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <Platforms>AnyCPU;x64</Platforms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
## Summary
- enable Windows cross-targeting for .NET builds
- correct ProcessStartInfo initialization for scheduling
- fix remote command-line parsing and RemoteManager return value

## Testing
- `/root/.dotnet/dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_689fafda9b3083228b20498214707eae