### PR TITLE
feat: add reusable loading spinner

### DIFF
--- a/reShutCLI/AutoUpdater.cs
+++ b/reShutCLI/AutoUpdater.cs
@@ -19,7 +19,10 @@ namespace reShutCLI
                 using var client = new HttpClient();
                 client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
 
-                var response = await client.GetAsync(RepositoryUrl);
+                var response = await LoadingSpinner.RunAsync(
+                    () => client.GetAsync(RepositoryUrl),
+                    "Checking for updates...",
+                    2000);
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -33,7 +36,10 @@ namespace reShutCLI
                     {
                         var asset = release.assets[0]; // Assuming the first asset is the installer
                         var downloadUrl = asset.browser_download_url;
-                        var installerPath = await DownloadInstaller(downloadUrl);
+                        var installerPath = await LoadingSpinner.RunAsync(
+                            () => DownloadInstaller(downloadUrl),
+                            "Downloading update...",
+                            2000);
 
                         if (!string.IsNullOrEmpty(installerPath))
                         {

--- a/reShutCLI/LoadingSpinner.cs
+++ b/reShutCLI/LoadingSpinner.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace reShutCLI
+{
+    internal static class LoadingSpinner
+    {
+        public static async Task RunAsync(Func<Task> action, string message, int delay = 1000)
+        {
+            await RunAsync(async () => { await action(); return true; }, message, delay);
+        }
+
+        public static async Task<T> RunAsync<T>(Func<Task<T>> action, string message, int delay = 1000)
+        {
+            var previousColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            using var cts = new CancellationTokenSource();
+
+            var spinnerTask = Task.Run(async () =>
+            {
+                char[] frames = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' };
+                int i = 0;
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    UIDraw.DrawCentered($"\r{frames[i++ % frames.Length]} {message}");
+                    await Task.Delay(100, cts.Token).ContinueWith(_ => { });
+                }
+            }, cts.Token);
+
+            var actionTask = action();
+            await Task.WhenAll(actionTask, Task.Delay(delay));
+
+            cts.Cancel();
+            await spinnerTask;
+            Console.Clear();
+            Console.ForegroundColor = previousColor;
+            return await actionTask;
+        }
+    }
+}

--- a/reShutCLI/ThemeLoader.cs
+++ b/reShutCLI/ThemeLoader.cs
@@ -42,37 +42,15 @@ namespace reShutCLI
             try
             {
                 Console.Title = "reShutCLI - Loading Theme...";
-                Console.ForegroundColor = ConsoleColor.DarkGray;
-                using var cts = new CancellationTokenSource();
 
-                // Start spinner in background
-                var spinnerTask = Task.Run(async () =>
-                {
-                    char[] frames = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' };
-                    int i = 0;
-                    while (!cts.Token.IsCancellationRequested)
-                    {
-                        UIDraw.DrawCentered($"\r{frames[i++ % frames.Length]} Fetching V2 theme from API...");
-                        await Task.Delay(100, cts.Token).ContinueWith(_ => { });
-                    }
-                }, cts.Token);
+                var response = await LoadingSpinner.RunAsync(
+                    () => client.GetStringAsync("http://api.elnino0916.de/api/v2/reshutcli/theme/default"),
+                    "Fetching V2 theme from API...");
 
-                // Perform API call
-                var fetchTask = client.GetStringAsync("http://api.elnino0916.de/api/v2/reshutcli/theme/default");
-
-                await Task.WhenAll(fetchTask, Task.Delay(1000));
-
-                var response = await fetchTask;
                 var theme = JsonSerializer.Deserialize<ApiTheme>(response);
-
                 Variables.MenuColor = theme.MenuColor;
                 Variables.LogoColor = theme.LogoColor;
                 Variables.SecondaryColor = theme.SecondaryColor;
-
-                // Stop spinner
-                cts.Cancel();
-                await spinnerTask;
-                Console.Clear();
             }
             catch (Exception)
             {

--- a/reShutCLI/UpdateChecker.cs
+++ b/reShutCLI/UpdateChecker.cs
@@ -36,7 +36,9 @@ namespace reShutCLI
             using var client = new HttpClient();
             client.DefaultRequestHeaders.UserAgent.ParseAdd("reShutCLI_UpdateSearch");
 
-            var response = await client.GetAsync(repositoryUrl);
+            var response = await LoadingSpinner.RunAsync(
+                () => client.GetAsync(repositoryUrl),
+                "Checking for updates...");
 
             if (response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
## Summary
- extract loading spinner into reusable `LoadingSpinner` helper
- use spinner for theme loading and update checks
- show 2 second spinner delay when updating

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68a1928ac31c83228b0cd5c01876b0c3